### PR TITLE
move samples in main package

### DIFF
--- a/eccodes.spec
+++ b/eccodes.spec
@@ -250,10 +250,10 @@ popd
 %{_libdir}/*.so.0*
 %dir %{_datadir}/%{name}
 %{_datadir}/%{name}/definitions
+%{_datadir}/%{name}/ifs_samples/
+%{_datadir}/%{name}/samples/
 
 %files doc
-%doc %{_datadir}/%{name}/ifs_samples/
-%doc %{_datadir}/%{name}/samples/
 %doc html
 %doc examples
 


### PR DESCRIPTION
Samples are not documentation, they are needed for coding new messages from scratch => libemos should thus not depend on eccodes-doc